### PR TITLE
getByQuery時、totalCountオプションを常に付与

### DIFF
--- a/src/Yjhm214/KintoneRestApi/KintoneRestApi.php
+++ b/src/Yjhm214/KintoneRestApi/KintoneRestApi.php
@@ -59,7 +59,7 @@ class KintoneRestApi{
 			$query .= $key.' ';
 		}
 
-		$request = $this->request->get(['app' => $appID, 'query' => $query, 'fields' => $fields], $command);
+		$request = $this->request->get(['app' => $appID, 'query' => $query, 'fields' => $fields, 'totalCount' => 'true'], $command);
 
 		$response = new Response($request);
 		return $response->getResponse();


### PR DESCRIPTION
レコードの一括取得時にtotalCount=trueを追加しました。
※引数追加や別functionでの対応も検討しましたが、常にtrueでも問題なしと判断しました。

https://cybozudev.zendesk.com/hc/ja/articles/202331474

