### PR TITLE
api_tokenのセッターを実装

### DIFF
--- a/src/Yjhm214/KintoneRestApi/KintoneRestApi.php
+++ b/src/Yjhm214/KintoneRestApi/KintoneRestApi.php
@@ -34,6 +34,10 @@ class KintoneRestApi{
 		$this->request = $request;
 	}
 
+	public function setApiToken($api_token)
+	{
+		$this->request->setApiToken($api_token);
+	}
 /*
 |--------------------------------------------------------------------------
 | CRUD

--- a/src/Yjhm214/KintoneRestApi/Request.php
+++ b/src/Yjhm214/KintoneRestApi/Request.php
@@ -33,6 +33,11 @@ class Request {
 		return $this->data;
 	}
 
+	public function setApiToken($api_token)
+	{
+		$this->api_token = $api_token;
+	}
+
 	private function setAuth($auth_default)
 	{
 		if ($auth_default == 'user_pass_auth') {


### PR DESCRIPTION
APIトークン認証で複数アプリを使用する際、APIトークンを書き換える必要があったためセッターを用意