### PR TITLE
ServiceProviderのshareをsingletonに修正

### DIFF
--- a/src/Yjhm214/KintoneRestApi/KintoneRestApiServiceProvider.php
+++ b/src/Yjhm214/KintoneRestApi/KintoneRestApiServiceProvider.php
@@ -30,7 +30,7 @@ class KintoneRestApiServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['KintoneRestApi'] = $this->app->share(function($app)
+	    $this->app->singleton('KintoneRestApi', function($app)
 	    {
 	      return new KintoneRestApi;
 	    });


### PR DESCRIPTION
laravel5.4でshareは削除されエラーが発生するため、singletonに変更しました。

参考URL：
https://github.com/thujohn/twitter/issues/169