### PR TITLE
BASIC認証に対応

### DIFF
--- a/src/Yjhm214/KintoneRestApi/KintoneRestApi.php
+++ b/src/Yjhm214/KintoneRestApi/KintoneRestApi.php
@@ -34,6 +34,10 @@ class KintoneRestApi{
 		$this->request = $request;
 	}
 
+	public function setApiToken($api_token)
+	{
+		$this->request->setApiToken($api_token);
+	}
 /*
 |--------------------------------------------------------------------------
 | CRUD

--- a/src/Yjhm214/KintoneRestApi/KintoneRestApiServiceProvider.php
+++ b/src/Yjhm214/KintoneRestApi/KintoneRestApiServiceProvider.php
@@ -30,7 +30,7 @@ class KintoneRestApiServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['KintoneRestApi'] = $this->app->share(function($app)
+	    $this->app->singleton('KintoneRestApi', function($app)
 	    {
 	      return new KintoneRestApi;
 	    });

--- a/src/Yjhm214/KintoneRestApi/Request.php
+++ b/src/Yjhm214/KintoneRestApi/Request.php
@@ -33,6 +33,11 @@ class Request {
 		return $this->data;
 	}
 
+	public function setApiToken($api_token)
+	{
+		$this->api_token = $api_token;
+	}
+
 	private function setAuth($auth_default)
 	{
 		if ($auth_default == 'user_pass_auth') {


### PR DESCRIPTION
cybozu.com でBasic認証を利用している場合、リクエストヘッダに「Authorization」ヘッダを付与できるよう実装しました。

参考）https://developer.cybozu.io/hc/ja/articles/201941754-kintone-REST-API%E3%81%AE%E5%85%B1%E9%80%9A%E4%BB%95%E6%A7%98#step8